### PR TITLE
Fix char_backend_file to manage file handles properly

### DIFF
--- a/systemc-components/backends/char_backend_file/include/char_backend_file.h
+++ b/systemc-components/backends/char_backend_file/include/char_backend_file.h
@@ -101,6 +101,7 @@ public:
         }
         socket.enqueue(EOF);
         fclose(r_file);
+        r_file = NULL;
     }
 
     void writefn(tlm::tlm_generic_payload& txn, sc_core::sc_time& t)
@@ -112,10 +113,21 @@ public:
                 SCP_ERR(()) << "Error writing to the file.\n";
             }
         }
-        fclose(w_file);
+        fflush(w_file);
     }
 
-    ~char_backend_file() {}
+    // Add destructor to clean up file handles
+    ~char_backend_file() 
+    {
+        if (w_file != NULL) {
+            fclose(w_file);
+            w_file = NULL;
+        }
+        if (r_file != NULL) {
+            fclose(r_file);
+            r_file = NULL;
+        }
+    }
 };
 // GSC_MODULE_REGISTER(char_backend_file);
 extern "C" void module_register();

--- a/tests/systemc-uarts/file-backend-test.cc
+++ b/tests/systemc-uarts/file-backend-test.cc
@@ -77,9 +77,12 @@ TEST_BENCH(TestFILE, FileReadWrite)
     m_initiator.do_write(0, 'o');
     m_initiator.do_write(0, 'm');
     m_initiator.do_write(0, 'm');
-    m_initiator.do_write(0, '\n');
-
+    
     sc_core::wait(1, sc_core::SC_NS);
+
+    m_initiator.do_write(0, '\n');
+    sc_core::wait(1, sc_core::SC_NS);
+
     sc_core::sc_stop();
 }
 


### PR DESCRIPTION
**Description:** This PR fixes an issue where char_backend_file closes the file handle immediately after the first transaction, causing subsequent writes to fail. (#35 )

**Changes:**
- `char_backend_file.h`: Replaced fclose with fflush in the writefn method to ensure data is flushed without closing the stream.
- `file-backend-test.cc`: Updated the test case to verify continuous data writing to the UART, clarifying both original and extended behaviors.

**Build & Test Environment Note:**
- I verified this fix based on the v5.0.1 (latest stable) tag.
- I attempted to test on main and v5.0.2, but I could not proceed because the required dependency libqemu-v10.1-v0.3 does not seem to be available in the public QEMU repository ([github.com/quic/qemu](https://www.google.com/search?q=https://github.com/quic/qemu)).

- Therefore, the verification was performed in the v5.0.1 environment, but the logic should be compatible with the latest branch.