### PR TITLE
win/arm64: Add accel whpx

### DIFF
--- a/cmake/boilerplate.cmake
+++ b/cmake/boilerplate.cmake
@@ -109,8 +109,6 @@ macro(gs_create_dymod MODULE_NAME)
   # Avoid to have the "lib" prefix on the name of the library
   set_target_properties(${MODULE_NAME} PROPERTIES PREFIX "")
 
-
-
   if ( TARGET_LIBS )
     add_dependencies(${MODULE_NAME} ${TARGET_LIBS})
     target_link_libraries(${MODULE_NAME} PUBLIC
@@ -118,9 +116,21 @@ macro(gs_create_dymod MODULE_NAME)
     )
   endif()
 
-    if (WIN32)
-        target_link_libraries(${MODULE_NAME} PRIVATE ws2_32 mswsock)
-    endif()
+  if (WIN32)
+    target_link_libraries(${MODULE_NAME} PRIVATE ws2_32 mswsock)
+
+    # When a dymod links against another dymod, the symbol `module_register`
+    # of the imported dymod shadows the same symbol of the importee.
+    # The .def file forces the export of the local module_register, and
+    # --export-all-symbols ensures every other symbol remains exported too
+    # (without it, the .def file restricts exports to only module_register,
+    # breaking test executables that link against the import library).
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${MODULE_NAME}_exports.def"
+        "EXPORTS\n    module_register\n")
+    target_sources(${MODULE_NAME} PRIVATE
+                  "${CMAKE_CURRENT_BINARY_DIR}/${MODULE_NAME}_exports.def")
+    target_link_options(${MODULE_NAME} PRIVATE -Wl,--export-all-symbols)
+  endif()
 
   foreach(T IN LISTS TARGET_LIBS)
     target_include_directories(

--- a/package-lock.cmake
+++ b/package-lock.cmake
@@ -27,7 +27,7 @@ CPMDeclarePackage(SCP
 CPMDeclarePackage(qemu
     NAME libqemu
     GIT_REPOSITORY ${GREENSOCS_GIT}${QEMU_PATH_NAME}.git
-    GIT_TAG libqemu-v11.0-v0.1
+    GIT_TAG libqemu-v11.0-v0.2
     GIT_SUBMODULES CMakeLists.txt
     GIT_SHALLOW ON
 )

--- a/qemu-components/common/include/qemu-instance.h
+++ b/qemu-components/common/include/qemu-instance.h
@@ -161,6 +161,7 @@ protected:
     std::string m_display_argument;
 
     cci::cci_param<std::string> p_accel;
+    cci::cci_param<std::string> p_whpx_args;
 
     void push_default_args()
     {
@@ -248,6 +249,14 @@ protected:
             push_tcg_mode_args();
         } else if (accel == "hvf" || accel == "kvm") {
             m_inst.push_qemu_arg(accel.c_str());
+        } else if (accel == "whpx") {
+            auto& whpx_args_str = p_whpx_args.get_value();
+            if (whpx_args_str.empty()) {
+                m_inst.push_qemu_arg("whpx");
+            } else {
+                std::string full_arg = "whpx," + whpx_args_str;
+                m_inst.push_qemu_arg(full_arg.c_str());
+            }
         } else {
             SCP_FATAL(()) << "Invalid accel property '" << accel << "'";
         }
@@ -300,6 +309,7 @@ public:
         , p_icount_mips("icount_mips_shift", 0, "The MIPS shift value for icount mode (1 insn = 2^(mips) ns)")
         , p_args("qemu_args", "", "additional space separated arguments")
         , p_accel("accel", "tcg", "Virtualization accelerator")
+        , p_whpx_args("whpx_args", "", "Additional WHPX accelerator properties (e.g. gicd-base-address=0x17000000)")
     {
         SCP_DEBUG(()) << "Libqbox QemuInstance constructor";
 
@@ -373,6 +383,7 @@ public:
 
     bool is_kvm_enabled() const { return p_accel.get_value() == "kvm"; }
     bool is_hvf_enabled() const { return p_accel.get_value() == "hvf"; }
+    bool is_whpx_enabled() const { return p_accel.get_value() == "whpx"; }
     bool is_tcg_enabled() const { return p_accel.get_value() == "tcg"; }
 
     /**

--- a/qemu-components/common/include/virtio/virtio-mmio.h
+++ b/qemu-components/common/include/virtio/virtio-mmio.h
@@ -71,9 +71,6 @@ public:
         }
 
         virtio_mmio_device.get_qemu_dev().set_prop_bool("force-legacy", true);
-
-        // force MMIO devices to use transport address (which will be 0, causing automatic ID)
-        virtio_mmio_device.get_qemu_dev().set_prop_bool("format_transport_address", false);
     }
 
     void end_of_elaboration() override

--- a/qemu-components/irq-ctrl/CMakeLists.txt
+++ b/qemu-components/irq-ctrl/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(arm_gicv2)
+add_subdirectory(arm_gicv2m)
 add_subdirectory(arm_gicv3)
 add_subdirectory(arm_gicv3_its)
 add_subdirectory(armv7m_nvic)

--- a/qemu-components/irq-ctrl/arm_gicv2m/CMakeLists.txt
+++ b/qemu-components/irq-ctrl/arm_gicv2m/CMakeLists.txt
@@ -1,0 +1,1 @@
+gs_create_dymod(arm_gicv2m)

--- a/qemu-components/irq-ctrl/arm_gicv2m/include/arm_gicv2m.h
+++ b/qemu-components/irq-ctrl/arm_gicv2m/include/arm_gicv2m.h
@@ -1,0 +1,99 @@
+/*
+ * Self-contained arm_gicv2m QBox module.
+ *
+ * Wraps QEMU's "arm-gicv2m" device as an independently loadable DLL module.
+ * When a GIC reference (v2 or v3) is passed as a constructor argument, SPI
+ * outputs are automatically bound to the GIC's SPI inputs.
+ *
+ * Copyright (c) 2025 Qualcomm Innovation Center, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _LIBQBOX_COMPONENTS_IRQ_CTRL_ARM_GICV2M_H
+#define _LIBQBOX_COMPONENTS_IRQ_CTRL_ARM_GICV2M_H
+
+#include <string>
+
+#include <systemc>
+#include <cci_configuration>
+
+#include <scp/report.h>
+
+#include <module_factory_registery.h>
+
+#include <cciutils.h>
+#include <device.h>
+#include <ports/target.h>
+#include <ports/qemu-initiator-signal-socket.h>
+#include <ports/qemu-target-signal-socket.h>
+
+class arm_gicv2m : public QemuDevice
+{
+protected:
+    cci::cci_param<unsigned int> p_base_spi;
+    cci::cci_param<unsigned int> p_num_spis;
+
+private:
+    sc_core::sc_object* m_gic;
+
+public:
+    sc_core::sc_vector<QemuInitiatorSignalSocket> spi_out;
+
+    QemuTargetSocket<> iface;
+
+    arm_gicv2m(const sc_core::sc_module_name& name, sc_core::sc_object* o, sc_core::sc_object* gic)
+        : arm_gicv2m(name, *(dynamic_cast<QemuInstance*>(o)), gic)
+    {
+    }
+
+    arm_gicv2m(const sc_core::sc_module_name& name, QemuInstance& inst, sc_core::sc_object* gic = nullptr)
+        : QemuDevice(name, inst, "arm-gicv2m")
+        , p_base_spi("base_spi", 0, "Start index of gic's spis")
+        , p_num_spis("num_spis", 0, "Number of gic's spis")
+        , m_gic(gic)
+        , spi_out("spi_out", p_num_spis)
+        , iface("iface", inst)
+    {
+    }
+
+    void before_end_of_elaboration() override
+    {
+        QemuDevice::before_end_of_elaboration();
+
+        m_dev.set_prop_int("base-spi", p_base_spi);
+        m_dev.set_prop_int("num-spi", p_num_spis);
+
+        if (m_gic) {
+            for (unsigned int i = 0; i < p_num_spis; i++) {
+                std::string spi_name = std::string(m_gic->name()) + ".spi_in_" + std::to_string(p_base_spi + i);
+                sc_core::sc_object* obj = gs::find_sc_obj(nullptr, spi_name);
+                if (!obj) {
+                    SCP_FATAL(SCMOD) << "Cannot find " << spi_name << " for auto-bind";
+                }
+                auto* target = dynamic_cast<QemuTargetSignalSocket*>(obj);
+                if (!target) {
+                    SCP_FATAL(SCMOD) << spi_name << " is not a QemuTargetSignalSocket";
+                }
+                spi_out[i].bind(*target);
+            }
+        }
+    }
+
+    void end_of_elaboration() override
+    {
+        QemuDevice::set_sysbus_as_parent_bus();
+        QemuDevice::end_of_elaboration();
+
+        qemu::SysBusDevice sbd(m_dev);
+
+        iface.init(sbd, 0);
+
+        for (unsigned int i = 0; i < p_num_spis; i++) {
+            spi_out[i].init_sbd(sbd, i);
+        }
+    }
+};
+
+extern "C" void module_register();
+
+#endif

--- a/qemu-components/irq-ctrl/arm_gicv2m/src/arm_gicv2m.cc
+++ b/qemu-components/irq-ctrl/arm_gicv2m/src/arm_gicv2m.cc
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Qualcomm Innovation Center, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <systemc>
+
+#include <arm_gicv2m.h>
+
+void module_register() { GSC_MODULE_REGISTER_C(arm_gicv2m, sc_core::sc_object*, sc_core::sc_object*); }

--- a/qemu-components/irq-ctrl/arm_gicv3/include/arm_gicv3.h
+++ b/qemu-components/irq-ctrl/arm_gicv3/include/arm_gicv3.h
@@ -151,7 +151,7 @@ public:
             vfiq_out[cpu].init_sbd(sbd, p_num_cpu * 3 + cpu);
         }
 
-        if (m_inst.is_kvm_enabled()) {
+        if (m_inst.is_kvm_enabled() || m_inst.is_whpx_enabled()) {
             uint64_t val;
             qemu::MemoryRegionOps::MemTxAttrs attrs = {};
             sc_core::sc_object* init_obj = gs::find_sc_obj(nullptr, "platform.global_peripheral_initiator_arm_0");

--- a/qemu-components/irq-ctrl/arm_gicv3/include/arm_gicv3.h
+++ b/qemu-components/irq-ctrl/arm_gicv3/include/arm_gicv3.h
@@ -63,6 +63,8 @@ public:
     {
         if (inst.is_kvm_enabled()) {
             return "kvm-arm-gicv3";
+        } else if (inst.is_whpx_enabled()) {
+            return "whpx-arm-gicv3";
         } else {
             return "arm-gicv3";
         }
@@ -103,8 +105,9 @@ public:
         m_dev.set_prop_int("num-irq", p_num_spi + NUM_PPI);
         m_dev.set_prop_int("revision", p_revision);
 
-        bool has_security_extensions = m_inst.is_kvm_enabled() ? false : p_has_security_extensions.get_value();
-        bool has_lpi = m_inst.is_kvm_enabled() ? false : p_has_lpi.get_value();
+        bool irqchip_in_kernel = m_inst.is_kvm_enabled() || m_inst.is_whpx_enabled();
+        bool has_security_extensions = irqchip_in_kernel ? false : p_has_security_extensions.get_value();
+        bool has_lpi = irqchip_in_kernel ? false : p_has_lpi.get_value();
         m_dev.set_prop_bool("has-security-extensions", has_security_extensions);
         m_dev.set_prop_bool("has-lpi", has_lpi);
         if (has_lpi) {


### PR DESCRIPTION
- **cmake/win32: Fix missing module_register symbol**
- **Fix Windows test DLL discovery by overriding add_test to inject PATH**
- **virtio-mmio: Remove prop "format_transport_address"**
- **whpx: add WHPX accelerator support with GICv3 and GICv2m**
- **WHPX: Fix reset**
- **Update to libqemu-v11.0-v0.2**

