### PR TITLE
cmake: Replace GREENSOCS_GIT with explicit dependency URLs

### DIFF
--- a/.github/workflows/macos-builds.yml
+++ b/.github/workflows/macos-builds.yml
@@ -21,7 +21,6 @@ jobs:
       - name: Configure
         run: >
           cmake --preset "${{ matrix.preset }}"
-          -DGREENSOCS_GIT="https://github.com/quic/"
           -DLIBQEMU_TARGETS="aarch64;hexagon"
 
       - name: Build

--- a/.github/workflows/ubuntu-builds.yml
+++ b/.github/workflows/ubuntu-builds.yml
@@ -21,7 +21,6 @@ jobs:
       - name: Configure
         run: >
           cmake --preset "${{ matrix.preset }}"
-          -DGREENSOCS_GIT="https://github.com/quic/"
           -DLIBQEMU_TARGETS="aarch64;hexagon"
 
       - name: Build

--- a/.github/workflows/windows-builds.yml
+++ b/.github/workflows/windows-builds.yml
@@ -33,9 +33,7 @@ jobs:
 
       - name: Configure
         run: >
-          cmake --preset=${{ matrix.preset }}
-          -DGREENSOCS_GIT="https://github.com/quic/"
-          -DLIBQEMU_TARGETS="aarch64;hexagon"
+          cmake --preset=${{ matrix.preset }} -DLIBQEMU_TARGETS="aarch64;hexagon"
 
       - name: Build
         run: cmake --build --preset=${{ matrix.preset }} --parallel $(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,6 @@ endif()
 set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ standard to build all targets.")
 set(CMAKE_CXX_STANDARD_REQUIRED ON CACHE BOOL "The with CMAKE_CXX_STANDARD selected C++ standard is a requirement.")
 set(GIT_BRANCH "main" CACHE STRING "Git branch from which to clone all gs repositoies")
-set(GREENSOCS_GIT "" CACHE STRING "Git directory from which to clone all gs repositories")
 set(PKG_LOCK "package-lock.cmake" CACHE STRING "Package lock which will be used by the user")
 set(QEMU_PATH_NAME "" CACHE STRING "The name of the path of qemu in the git directory")
 
@@ -50,6 +49,12 @@ set(CMAKE_FIND_USE_PACKAGE_REGISTRY FALSE)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
+
+# Dependencies URLs
+set(LIBQEMU_GIT "https://github.com/quic/qemu.git" CACHE STRING "libqemu  git url")
+set(SYSTEMC_GIT "https://github.com/accellera-official/systemc.git" CACHE STRING "SystemC git url")
+set(CCI_GIT "https://github.com/accellera-official/cci.git" CACHE STRING "SystemC Configuration, Control and Inspection (CCI) Library git url")
+set(SCP_GIT "https://github.com/accellera-official/systemc-common-practices.git" CACHE STRING "SystemC Common Practices (SCP) git url")
 
 # Generate a compile_commands.json file for our build,
 # for use by clang_complete, YouCompleteMe, vscode, etc.
@@ -84,50 +89,6 @@ file(
 )
 include(${CMAKE_CURRENT_BINARY_DIR}/cmake/CPM.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/boilerplate.cmake)
-
-macro(determine_qemu_git_path)
-    string(FIND "${GREENSOCS_GIT}" "github" GITHUB_URL)
-
-    if(GITHUB_URL EQUAL -1)
-        set(QEMU_PATH_NAME "qemu/qemu")
-    else()
-        set(QEMU_PATH_NAME "qemu")
-    endif()
-
-    message(STATUS "QEMU_PATH_NAME=${QEMU_PATH_NAME}")
-endmacro()
-
-macro(determine_qbox_git_url)
-    execute_process(
-        COMMAND git config --get remote.origin.url
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        OUTPUT_VARIABLE GIT_URL
-    )
-
-    string(REGEX MATCH "(.*\/)" GREENSOCS_GIT_ORIGIN "${GIT_URL}")
-    string(
-        REGEX
-        REPLACE "(.*)/sandboxes/[^\/]*/(.*)" "\\1/"
-        GREENSOCS_GIT_ORIGIN "${GREENSOCS_GIT_ORIGIN}"
-    )
-
-    if("${GREENSOCS_GIT}" STREQUAL "")
-        set(GREENSOCS_GIT "${GREENSOCS_GIT_ORIGIN}")
-    endif()
-
-    determine_qemu_git_path()
-
-    if(EXISTS "${PROJECT_SOURCE_DIR}/Packages")
-        if("${GREENSOCS_GIT}" STREQUAL "")
-            set(GREENSOCS_GIT "https://git.codelinaro.org/clo/private/qqvp/")
-        endif()
-    endif()
-
-    message(STATUS "GREENSOCS_GIT = ${GREENSOCS_GIT}")
-endmacro()
-
-determine_qbox_git_url()
 
 # Allow using package-lock.cmake files in projects using this boilerplate to
 # pin repos, etc.
@@ -381,7 +342,7 @@ if (NOT WITHOUT_QEMU)
     # submodule. See https://gitlab.kitware.com/cmake/cmake/-/issues/20579
     CPMAddPackage(
         NAME qemu
-        GIT_REPOSITORY "${GREENSOCS_GIT}/${QEMU_PATH_NAME}.git"
+        GIT_REPOSITORY "${LIBQEMU_GIT}"
         GIT_TAG "${GIT_BRANCH}"
         GIT_SHALLOW TRUE
         GIT_SUBMODULES "CMakeLists.txt"

--- a/cmake/boilerplate.cmake
+++ b/cmake/boilerplate.cmake
@@ -20,7 +20,7 @@ macro(install_systemc)
     else()
         gs_addexpackage(
             NAME SystemCLanguage
-            GIT_REPOSITORY https://github.com/accellera-official/systemc.git
+            GIT_REPOSITORY ${SYSTEMC_GIT}
             GIT_TAG febde7a3e007ce3030cf574a4cb6fcc13d0ed820
             GIT_SHALLOW OFF
             OPTIONS "ENABLE_SUSPEND_ALL" "ENABLE_PHASE_CALLBACKS"
@@ -48,7 +48,7 @@ macro(install_systemc_dependencies)
 
     gs_addexpackage(
         NAME SystemCCCI
-        GIT_REPOSITORY https://github.com/accellera-official/cci.git
+        GIT_REPOSITORY ${CCI_GIT}
         GIT_TAG 915c189f6916ab56db773b2da20ebc06fe8f24e9
         GIT_SHALLOW True
         OPTIONS "SYSTEMCCCI_BUILD_TESTS OFF"
@@ -56,7 +56,7 @@ macro(install_systemc_dependencies)
 
     gs_addexpackage(
         NAME SCP
-        GIT_REPOSITORY https://github.com/accellera-official/systemc-common-practices.git
+        GIT_REPOSITORY ${SCP_GIT}
         GIT_TAG 6830c915bb691d9b505b17ac631f1ff305fe9c17
         GIT_SHALLOW True
     )

--- a/package-lock.cmake
+++ b/package-lock.cmake
@@ -5,7 +5,7 @@
 CPMDeclarePackage(SystemCLanguage
   NAME SystemCLanguage
   GIT_TAG febde7a3e007ce3030cf574a4cb6fcc13d0ed820 # TODO: Replace with release > 3.0.2
-  GIT_REPOSITORY https://github.com/accellera-official/systemc.git
+  GIT_REPOSITORY ${SYSTEMC_GIT}
   GIT_SHALLOW OFF
   OPTIONS
       "ENABLE_SUSPEND_ALL"
@@ -15,8 +15,8 @@ CPMDeclarePackage(SystemCLanguage
 # SCP
 CPMDeclarePackage(SCP
   NAME SCP
-  GIT_TAG 0821c329a1df363503f5ea12309cc5fa2c064530 
-  GIT_REPOSITORY https://github.com/accellera-official/systemc-common-practices.git
+  GIT_TAG 0821c329a1df363503f5ea12309cc5fa2c064530
+  GIT_REPOSITORY ${SCP_GIT}
   # https://cmake.org/cmake/help/latest/module/ExternalProject.html#git
   # If GIT_SHALLOW is enabled then GIT_TAG works only with branch names
   # and tags. A commit hash is not allowed.
@@ -26,7 +26,7 @@ CPMDeclarePackage(SCP
 # qemu (unversioned)
 CPMDeclarePackage(qemu
     NAME libqemu
-    GIT_REPOSITORY ${GREENSOCS_GIT}${QEMU_PATH_NAME}.git
+    GIT_REPOSITORY ${LIBQEMU_GIT}
     GIT_TAG libqemu-v11.0-v0.2
     GIT_SUBMODULES CMakeLists.txt
     GIT_SHALLOW ON

--- a/platforms/cortex-m55-remote/package-lock.cmake
+++ b/platforms/cortex-m55-remote/package-lock.cmake
@@ -4,7 +4,7 @@
 # qemu (unversioned)
 CPMDeclarePackage(qemu
     NAME libqemu
-    GIT_REPOSITORY ${GREENSOCS_GIT}qemu.git
+    GIT_REPOSITORY ${LIBQEMU_GIT}
     GIT_TAG libqemu-v7.0.50-v1.3.2
     GIT_SUBMODULES CMakeLists.txt
     GIT_SHALLOW on


### PR DESCRIPTION
Remove the dynamic GREENSOCS_GIT detection macro and replace all
dependency git URLs with explicit, named variables (LIBQEMU_GIT,
SYSTEMC_GIT, CCI_GIT, SCP_GIT) rooted at a configurable GITHUB_URL.

Also remove -DGREENSOCS_GIT from CI workflows as it is no longer needed.

Signed-off-by: Jerome Haxhiaj <jhaxhiaj@qti.qualcomm.com>
