### PR TITLE
Fix windows tests

### DIFF
--- a/systemc-components/common/include/remote.h
+++ b/systemc-components/common/include/remote.h
@@ -1064,7 +1064,9 @@ public:
                 m_partner_process_manager.set_partner_process(partner_handle);
                 m_partner_process_manager.on_partner_exit([&]() {
                     std::cerr << "remote process (" << get_current_process_id() << ") detected parent ("
-                              << GetProcessId(partner_handle) << ") exit!" << std::endl;
+                              << GetProcessId(m_partner_process_manager.get_partner_process()) << ") exit!"
+                              << std::endl;
+                    stop_and_exit();
                 });
                 return;
             });

--- a/systemc-components/common/include/runonsysc.h
+++ b/systemc-components/common/include/runonsysc.h
@@ -188,7 +188,7 @@ public:
         return core && (std::this_thread::get_id() == core->thread_id);
     }
 
-    void end_of_simulation()
+    void end_of_simulation() override
     {
         auto core = m_core;
         if (!core) return;

--- a/systemc-components/common/src/dynlib_loader.cc
+++ b/systemc-components/common/src/dynlib_loader.cc
@@ -18,6 +18,7 @@
 #include <filesystem>
 
 #include <dynlib_loader.h>
+#include <scp/report.h>
 
 #if defined(_WIN32)
 #include <Lmcons.h>
@@ -45,12 +46,20 @@ static fs::path get_cleanup_helper_path()
 {
     char exe_path[MAX_PATH];
     DWORD len = GetModuleFileNameA(NULL, exe_path, MAX_PATH);
-    if (len == 0 || len >= MAX_PATH) {
-        return "";
+    if (len > 0 && len < MAX_PATH) {
+        fs::path helper_path = fs::path(exe_path).parent_path() / "dll_cleanup_helper.exe";
+        if (fs::exists(helper_path)) {
+            return helper_path;
+        }
     }
 
-    fs::path helper_path = fs::path(exe_path).parent_path() / "dll_cleanup_helper.exe";
-    return helper_path;
+    // Fallback: search PATH
+    char found[MAX_PATH];
+    if (SearchPathA(NULL, "dll_cleanup_helper.exe", NULL, MAX_PATH, found, NULL)) {
+        return fs::path(found);
+    }
+
+    return "";
 }
 
 /**
@@ -136,6 +145,8 @@ public:
 
 class DefaultLibraryLoader : public qemu::LibraryLoaderIface
 {
+    SCP_LOGGER(());
+
 private:
     std::string m_last_error;
 
@@ -278,7 +289,7 @@ private:
 
         // Spawn a cleanup process that will delete the DLL after this process exits
         if (!spawn_cleanup_process(temp_path)) {
-            std::cerr << "Warning: Failed to spawn cleanup process for: " << temp_path.string() << std::endl;
+            SCP_FATAL(()) << "Failed to spawn cleanup process for: " << temp_path.string();
         }
 
         return std::make_shared<Library>(handle);


### PR DESCRIPTION
- Search for dll cleanup helper in the path otherwise fails the tests
- Fix termination of the remote process
- Add missing override specified in runonsystemc