### PR TITLE
cmake: use libqemu compile definitions for library filenames

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,17 +352,6 @@ if (NOT WITHOUT_QEMU)
         list(APPEND TARGET_LIBS "libqemu")
     endif()
 
-    foreach(target ${LIBQEMU_TARGETS})
-        # The quite complex generator expressions does the followings:
-        #   - fetch the library name through the INTERFACE_LINK_LIBRARIES property
-        #   - evaluate it as a generator expression since it can contains
-        #     $<BUILD_INTERFACE> and $<INSTALL_INTERFACE> in a list
-        #   - join the result to remove empty elements in the final list
-        target_compile_definitions(${PROJECT_NAME}
-            PRIVATE
-                LIBQEMU_TARGET_${target}_LIBRARY="$<JOIN:$<GENEX_EVAL:$<TARGET_PROPERTY:libqemu-${target},INTERFACE_LINK_LIBRARIES>>,>")
-    endforeach()
-
     target_include_directories(
         ${PROJECT_NAME} PUBLIC
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/qemu-components/common/include>

--- a/package-lock.cmake
+++ b/package-lock.cmake
@@ -27,7 +27,7 @@ CPMDeclarePackage(SCP
 CPMDeclarePackage(qemu
     NAME libqemu
     GIT_REPOSITORY ${LIBQEMU_GIT}
-    GIT_TAG libqemu-v11.0-v0.2
+    GIT_TAG libqemu-v11.0-v0.3
     GIT_SUBMODULES CMakeLists.txt
     GIT_SHALLOW ON
 )


### PR DESCRIPTION
Remove the per-target generator expression loop that queried libqemu-<arch> INTERFACE_LINK_LIBRARIES to extract shared library filenames. libqemu now provides these as INTERFACE compile definitions (LIBQEMU_TARGET_<arch>_LIBRARY) directly on the libqemu target, so linking libqemu is sufficient.