### PR TITLE
libqemu: Move to libqemu-v11.0-v0.4

### DIFF
--- a/package-lock.cmake
+++ b/package-lock.cmake
@@ -27,7 +27,7 @@ CPMDeclarePackage(SCP
 CPMDeclarePackage(qemu
     NAME libqemu
     GIT_REPOSITORY ${LIBQEMU_GIT}
-    GIT_TAG libqemu-v11.0-v0.3
+    GIT_TAG libqemu-v11.0-v0.4
     GIT_SUBMODULES CMakeLists.txt
     GIT_SHALLOW ON
 )


### PR DESCRIPTION
This qemu releases  removes VirtIOMMIOProxy:format_transport_address
from libqemu to align with upstream Qemu.

Signed-off-by: Jerome Haxhiaj <jhaxhiaj@qti.qualcomm.com>
