### PR TITLE
cmake: Use system-installed libzip instead of building from source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ set(CMAKE_FIND_USE_PACKAGE_REGISTRY FALSE)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
+set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries" FORCE)
 
 # Dependencies URLs
 set(LIBQEMU_GIT "https://github.com/qualcomm/qemu.git" CACHE STRING "libqemu  git url")
@@ -224,11 +225,14 @@ FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibELF DEFAULT_MSG
 
 mark_as_advanced(LIBELF_INCLUDE_DIR LIBELF_LIBRARIES)
 
+# System / local packages (must be installed on the host)
 find_package(Threads REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBZIP REQUIRED IMPORTED_TARGET libzip)
 
+# CPM packages (fetched from source)
 gs_addexpackage("gh:google/googletest#v1.15.2")
 gs_addexpackage("gh:lua/lua#v5.4.2")
-gs_addexpackage("gh:nih-at/libzip#v1.11.3")
 gs_addexpackage("gh:TheLartians/PackageProject.cmake@1.4.1")
 
 find_package(Git QUIET)
@@ -407,7 +411,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
         Threads::Threads
         rpc
         ${CROW_DEP}
-        zip
+        PkgConfig::LIBZIP
         ${PYBIND11_EMBED}
         ${CMAKE_DL_LIBS}
 )
@@ -418,7 +422,7 @@ set(QBOX_INCLUDE_DIR "${QEMU_INCLUDE_DIR};${CMAKE_CURRENT_SOURCE_DIR}/systemc-co
 gs_export(${PROJECT_NAME} ${QBOX_INCLUDE_DIR})
 
 if (NOT DEFINED GS_ONLY)
-    install(TARGETS rpc zip)
+    install(TARGETS rpc)
 endif()
 
 list(APPEND TARGET_LIBS ${PROJECT_NAME})

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -19,20 +19,20 @@ if { [ -e /etc/os-release ] && OS_RELEASE="/etc/os-release"; } || \
         if [ "${VERSION_ID}" = "24.04" ]; then
             apt install cmake g++ gcc git libasio-dev libelf-dev libepoxy-dev \
                 libglib2.0-dev libjpeg-dev libpixman-1-dev libsdl2-dev \
-                libslirp-dev libasio-dev  libvirglrenderer-dev meson \
-                ninja-build ocl-icd-opencl-dev python3 python3-dev \
+                libslirp-dev libasio-dev  libvirglrenderer-dev libzip-dev \
+                meson ninja-build ocl-icd-opencl-dev python3 python3-dev \
                 python3-venv
         elif [ "${VERSION_ID}" = "22.04" ]; then
             apt install cmake g++ gcc git libasio-dev libelf-dev libepoxy-dev \
                 libglib2.0-dev libjpeg-dev libpixman-1-dev libsdl2-dev \
-                libslirp-dev libasio-dev libvirglrenderer-dev meson \
-                ninja-build ocl-icd-opencl-dev python3 python3-dev \
+                libslirp-dev libasio-dev libvirglrenderer-dev libzip-dev \
+                meson ninja-build ocl-icd-opencl-dev python3 python3-dev \
                 python3-tomli python3-venv
         elif [ "${VERSION_ID}" = "20.04" ]; then
             apt install cmake g++ gcc git libasio-dev libelf-dev libepoxy-dev \
                 libglib2.0-dev libjpeg-dev libpixman-1-dev libsdl2-dev \
-                libslirp-dev libasio-dev libvirglrenderer-dev meson \
-                ninja-build ocl-icd-opencl-dev python3 python3-dev \
+                libslirp-dev libasio-dev libvirglrenderer-dev libzip-dev \
+                meson ninja-build ocl-icd-opencl-dev python3 python3-dev \
                 python3-pip python3-venv
             pip install --user tomli
         else
@@ -45,8 +45,9 @@ if { [ -e /etc/os-release ] && OS_RELEASE="/etc/os-release"; } || \
 
         # Pacboy handle package prefixes automatically
         pacboy -S --noconfirm --needed \
-            toolchain cmake gtk3 libnfs libssh meson ninja pixman pkgconf \
-            python python-pexpect SDL2 zstd libelf asio libslirp
+            toolchain cmake gtk3 libnfs libssh libzip libelf libslirp \
+            meson ninja pixman pkgconf python python-pexpect SDL2 \
+            zstd asio
     fi
 else
     case "$(uname)" in
@@ -55,13 +56,13 @@ else
             readonly MAJOR_VERSION
 
             if [ "${MAJOR_VERSION}" = "26" ]; then
-                brew install asio bison cmake jpeg libelf libslirp meson ninja \
-                    python3 sdl2
-                pip install --user numpy pexpect
+                brew install asio bison cmake jpeg libelf libslirp libzip meson \
+                    ninja python3 sdl2
+                pip install --user pexpect numpy
             elif [ "${MAJOR_VERSION}" = "15" ]; then
-                brew install asio bison cmake jpeg libelf libslirp meson ninja \
-                    python3 sdl2
-                pip install --user numpy pexpect
+                brew install asio bison cmake jpeg libelf libslirp libzip meson \
+                    ninja python3 sdl2
+                pip install --user pexpect numpy
             else
                 unsupported_operating_system
             fi

--- a/systemc-components/common/include/reg_model_maker/reg_model_maker.h
+++ b/systemc-components/common/include/reg_model_maker/reg_model_maker.h
@@ -12,7 +12,6 @@
 #include <scp/report.h>
 #include <rapidjson/include/rapidjson/document.h>
 #include <zip.h>
-#include <zipint.h>
 #include <cciutils.h>
 #include <gs_memory.h>
 #include <router.h>


### PR DESCRIPTION
Replace the CPM-fetched libzip with find_package via pkg-config,
requiring libzip to be pre-installed on the host. This speeds up
configuration and avoids building libzip from source in-tree.

Changes:
- Use pkg_check_modules(LIBZIP) instead of CPM fetch, avoiding broken
  CMake config files shipped by Ubuntu's libzip-dev (which reference
  tool binaries from the missing libzip-tools package)
- Add libzip to install_dependencies.sh for all supported platforms
  (Ubuntu, MSYS2, macOS)
- Set BUILD_SHARED_LIBS=ON explicitly, since CPM-fetched libzip was
  previously setting this as a side effect via its option() call;
  without it, SystemC defaults to static on Windows, causing
  multiple-definition errors when plugin DLLs link against both
  libqbox.dll and libsystemc.a
- Remove unused #include <zipint.h> (internal libzip header not
  available in the system package)

Signed-off-by: Jerome Haxhiaj <jhaxhiaj@qti.qualcomm.com>
