### PR TITLE
cmake: Move to libqemu-v11.0-v0.5

### DIFF
--- a/package-lock.cmake
+++ b/package-lock.cmake
@@ -27,7 +27,7 @@ CPMDeclarePackage(SCP
 CPMDeclarePackage(qemu
     NAME libqemu
     GIT_REPOSITORY ${LIBQEMU_GIT}
-    GIT_TAG libqemu-v11.0-v0.4
+    GIT_TAG libqemu-v11.0-v0.5
     GIT_SUBMODULES CMakeLists.txt
     GIT_SHALLOW ON
 )


### PR DESCRIPTION
changelog:
- hw/core/qdev: skip vmstate register/unregister under CONFIG_LIBQEMU
- qemu.cmake: use ninja by default to build QEMU
- Fix missing src vaddr index
- github-workflows: fix duplicate CI runs on push and pull_request

Signed-off-by: Jerome Haxhiaj <jhaxhiaj@qti.qualcomm.com>
