### PR TITLE
char_backend_stdio: raise SIGBREAK on Ctrl+\ on Windows

### DIFF
--- a/systemc-components/backends/char_backend_stdio/include/char_backend_stdio.h
+++ b/systemc-components/backends/char_backend_stdio/include/char_backend_stdio.h
@@ -105,6 +105,10 @@ private:
         for (DWORD i = 0; i < cNumRead; ++i) {
             const INPUT_RECORD& record = irInBuf[i];
             if (record.EventType == KEY_EVENT && record.Event.KeyEvent.bKeyDown) {
+                if (record.Event.KeyEvent.uChar.AsciiChar == 0x1c) {
+                    raise(SIGBREAK);
+                    return;
+                }
                 enqueue(record.Event.KeyEvent.uChar.AsciiChar);
             }
         }


### PR DESCRIPTION
On Linux, Ctrl+\ generates SIGQUIT which is handled by SigHandler to terminate the process. On Windows, Ctrl+Break generates SIGBREAK which has the same effect, but the Break key is not available on all keyboards.

Detect the Ctrl+\ character (0x1c) in enqueue_multiple() and raise SIGBREAK to replicate the Linux SIGQUIT behaviour on Windows.