### PR TITLE
display: pick gl=off on Windows where virglrenderer is unavailable

### DIFF
--- a/qemu-components/display/src/display.cc
+++ b/qemu-components/display/src/display.cc
@@ -210,7 +210,14 @@ display::display(const sc_core::sc_module_name& _name, sc_core::sc_object* o)
     // Use QEMU's integrated display only if we are NOT on MacOS.
     // On MacOS use libqbox's display SystemC module.
     QemuDevice* gpu = (dynamic_cast<QemuDevice*>(o));
-    gpu->get_qemu_inst().set_display_arg("sdl,gl=on");
+    std::string display_params("sdl");
+#ifdef _WIN32
+    display_params += ",gl=off";
+#else
+    display_params += ",gl=on";
+#endif
+    gpu->get_qemu_inst().set_display_arg(display_params);
+    SCP_INFO(SCMOD) << "display: request backend: " << display_params;
 #endif
 }
 


### PR DESCRIPTION
Change depends on landing libqemu/v11.0 MR !1571 first.

On Windows-on-ARM, libqemu is built without virglrenderer because
msys2 clangarm64 does not ship it. Requesting "sdl,gl=on" segfaults
at SDL/EGL init since the GL path cannot establish a virgl-backed
context.

Pick "sdl,gl=off" on _WIN32 and "sdl,gl=on" elsewhere. The 2D path
in libqemu requires a companion fix to ui/sdl2 so that sdl2_2d_switch
creates the SDL_Renderer after dpy_window_create; without that fix
the SDL window opens but never paints.

Also log the chosen backend at INFO so it is visible at default
verbosity.

Co-Authored-By: Claude <noreply@anthropic.com>
Signed-off-by: Steve Aarnio <saarnio@qti.qualcomm.com>
