### PR TITLE
call 'dlerror' in case of 'dlopen' failure to make debugging easier

### DIFF
--- a/systemc-components/common/src/dynlib_loader.cc
+++ b/systemc-components/common/src/dynlib_loader.cc
@@ -205,6 +205,9 @@ private:
         handle = LoadLibraryExA(lib_name.c_str(), NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
 #else
         handle = dlopen(lib_name.c_str(), RTLD_NOW);
+        if (handle == nullptr) {
+            m_last_error = "load_library_internal: Library " + lib_name + " is not loaded (" + dlerror() + ").";
+        }
 #endif
         return handle;
     }


### PR DESCRIPTION
Hello,

I work in a RHEL8 environment where all the libraries required by qemu and qbox are not in the default system path.
Adding this error message, help me to correctly update the LD_LIBRARY_PATH environment variable.

Best regards,
Benoît