### PR TITLE
systemc-components: fix a smmu500 reset issue

### DIFF
--- a/systemc-components/smmu500/src/smmu500.cc
+++ b/systemc-components/smmu500/src/smmu500.cc
@@ -93,8 +93,9 @@ smmu500<BUSWIDTH>::smmu500(sc_core::sc_module_name _name)
     reset.register_value_changed_cb([&](bool value) {
         if (value) {
             SCP_WARN(()) << "Reset";
+            M.reset(value);
+            start_of_simulation();
         }
-        M.reset(value);
     });
 }
 


### PR DESCRIPTION
- the registers initialized in start_of_simulation() will be reset to their default values after reset and this may cause problems unless start_of_simulation() is called from the reset signal handler.