### PR TITLE
qemu-components: use bql in the qemu SC target socket while reading a…

### DIFF
--- a/qemu-components/common/include/ports/target.h
+++ b/qemu-components/common/include/ports/target.h
@@ -26,6 +26,7 @@ public:
 protected:
     qemu::MemoryRegion m_mr;
     std::shared_ptr<qemu::AddressSpace> m_as;
+    QemuInstance* m_inst = nullptr;
 
     void init_as()
     {
@@ -67,14 +68,16 @@ protected:
     }
 
 public:
-    void init(qemu::SysBusDevice sbd, int mmio_idx)
+    void init(qemu::SysBusDevice sbd, int mmio_idx, QemuInstance& inst)
     {
+        m_inst = &inst;
         m_mr = sbd.mmio_get_region(mmio_idx);
         init_as();
     }
 
-    void init_with_mr(qemu::MemoryRegion mr)
+    void init_with_mr(qemu::MemoryRegion mr, QemuInstance& inst)
     {
+        m_inst = &inst;
         m_mr = mr;
         init_as();
     }
@@ -95,6 +98,15 @@ public:
 
         current_cpu_save = push_current_cpu(trans);
 
+        /*
+         * QEMU device state (ptimer transactions, virtual clock, etc.) is BQL-protected.
+         * SystemC threads reaching this path do not implicitly hold the BQL, so acquire
+         * it for the duration of the QEMU dispatch. The BQL is recursive, so this is
+         * safe even when the caller (e.g. QemuInitiatorSocket reentrancy>1 path) already
+         * holds it.
+         */
+        m_inst->get().lock_iothread();
+
         switch (trans.get_command()) {
         case tlm::TLM_READ_COMMAND:
             res = m_as->read(addr, data, size, attrs);
@@ -106,9 +118,12 @@ public:
 
         default:
             /* TLM_IGNORE_COMMAND already handled above */
+            m_inst->get().unlock_iothread();
             assert(false);
             return;
         }
+
+        m_inst->get().unlock_iothread();
 
         trans.set_extension(new QemuMrHintTlmExtension(m_mr, addr));
 
@@ -174,9 +189,9 @@ public:
         TlmTargetSocket::bind(m_bridge);
     }
 
-    void init(qemu::SysBusDevice sbd, int mmio_idx) { m_bridge.init(sbd, mmio_idx); }
+    void init(qemu::SysBusDevice sbd, int mmio_idx) { m_bridge.init(sbd, mmio_idx, m_inst); }
 
-    void init_with_mr(qemu::MemoryRegion mr) { m_bridge.init_with_mr(mr); }
+    void init_with_mr(qemu::MemoryRegion mr) { m_bridge.init_with_mr(mr, m_inst); }
 };
 
 #endif


### PR DESCRIPTION
acquire the qemu BQL in the SC qemu target socket b_transport in the duration of the qemu read and write dispatch to mitigate reentrancy issues.