### PR TITLE
libqemu: Move to libqemu-v11.0-v0.8

### DIFF
--- a/package-lock.cmake
+++ b/package-lock.cmake
@@ -27,7 +27,7 @@ CPMDeclarePackage(SCP
 CPMDeclarePackage(qemu
     NAME libqemu
     GIT_REPOSITORY ${LIBQEMU_GIT}
-    GIT_TAG libqemu-v11.0-v0.6
+    GIT_TAG libqemu-v11.0-v0.8
     GIT_SUBMODULES CMakeLists.txt
     GIT_SHALLOW ON
 )


### PR DESCRIPTION
Changelog:
    - libqemu: expose TCG plugin API through LibQemuExports
    - contrib/plugins: install idlinker on Windows and stage it for the loader
    - target/riscv: handle platform-defined local interrupts (IRQ >= 12)
    - target/riscv: add vendor CSR 0x7c1 as no-op
    - virtio-gpu: Fix vircl OpenCL device (capsets, QOM type, timers)

Signed-off-by: Jerome Haxhiaj <jhaxhiaj@qti.qualcomm.com>
