### PR TITLE
cpu_riscv64: add resetvec, pmp, smaia, ssaia CCI params

### DIFF
--- a/qemu-components/cpu_riscv/cpu_riscv64/include/riscv64.h
+++ b/qemu-components/cpu_riscv/cpu_riscv64/include/riscv64.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <functional>
 
+#include <cci_configuration>
 #include <libqemu-cxx/target/riscv.h>
 
 #include <libgssync.h>
@@ -22,6 +23,12 @@ class QemuCpuRiscv64 : public QemuCpu
 {
 public:
     sc_core::sc_vector<QemuTargetSignalSocket> irq_in;
+
+    // CCI parameters for RISC-V CPU configuration
+    cci::cci_param<uint64_t> p_resetvec;
+    cci::cci_param<bool> p_pmp;
+    cci::cci_param<bool> p_smaia;
+    cci::cci_param<bool> p_ssaia;
 
 protected:
     uint64_t m_hartid;
@@ -44,6 +51,11 @@ public:
          */
         , m_irq_ev(true)
         , irq_in("irq_in", 32)
+        // Initialize CCI parameters with default values
+        , p_resetvec("resetvec", 0x0, "Reset vector address")
+        , p_pmp("pmp", false, "Enable Physical Memory Protection")
+        , p_smaia("smaia", false, "Enable Smaia (AIA M-mode CSRs)")
+        , p_ssaia("ssaia", false, "Enable Ssaia (AIA S-mode CSRs)")
     {
         m_external_ev |= m_irq_ev;
         for (auto& irq : irq_in) {
@@ -57,6 +69,17 @@ public:
 
         qemu::CpuRiscv64 cpu(get_qemu_dev());
         cpu.set_prop_int("hartid", m_hartid);
+
+        // Set properties from CCI parameters
+        cpu.set_prop_int("resetvec", p_resetvec);
+        cpu.set_prop_bool("pmp", p_pmp);
+        if (p_smaia) {
+            cpu.set_prop_bool("smaia", true);
+        }
+        if (p_ssaia) {
+            cpu.set_prop_bool("ssaia", true);
+        }
+
         cpu.set_mip_update_callback(std::bind(&QemuCpuRiscv64::mip_update_cb, this, std::placeholders::_1));
     }
 


### PR DESCRIPTION
SiFive S51 needs a configurable reset vector, PMP, and the RISC-V AIA extensions (Smaia/Ssaia) for vendor RNMI CSR access (0x350-0x353). Mirror the cpu_riscv32 CCI-param idiom, adding only the four properties SiFive S51 uses; each map to an existing QEMU rv64 CPU property.