### PR TITLE
glib_shim: add opaque GLib type declarations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,16 @@ if (NOT WITHOUT_QEMU)
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}>
     )
 
+    # Glib shim path (BUILD_INTERFACE only): shadows system glib for any
+    # in-tree TU that transitively includes qemu-plugin.h via libqemu's
+    # generated typedefs.h (which sits inside an extern "C" block in
+    # libqemu.h). Forward-decls of GArray/GByteArray are sufficient
+    # because qbox C++ never accesses glib internals.
+    target_include_directories(
+        ${PROJECT_NAME} BEFORE PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/qemu-components/common/include/glib_shim>
+    )
+
     target_link_libraries(${PROJECT_NAME} PUBLIC libqemu)
 
     set(LIBQEMU_CXX_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/qemu-components/common/include/libqemu-cxx)

--- a/package-lock.cmake
+++ b/package-lock.cmake
@@ -27,7 +27,7 @@ CPMDeclarePackage(SCP
 CPMDeclarePackage(qemu
     NAME libqemu
     GIT_REPOSITORY ${LIBQEMU_GIT}
-    GIT_TAG libqemu-v11.0-v0.6
+    GIT_TAG libqemu-v11.0-v0.8
     GIT_SUBMODULES CMakeLists.txt
     GIT_SHALLOW ON
 )

--- a/qemu-components/common/include/glib_shim/glib.h
+++ b/qemu-components/common/include/glib_shim/glib.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ *
+ * Forward-decl-only glib.h shim, on libqemu-cxx's PRIVATE include path
+ * BEFORE the system glib path.
+ *
+ * Why: libqemu's generated typedefs.h is wrapped in extern "C" by
+ * libqemu/libqemu.h, and qemu-plugin.h does `#include <glib.h>`. Modern
+ * glib.h has C++ template inline functions (g_steal_pointer, ...) that
+ * fail with "template with C linkage" inside extern "C". qbox's plugin
+ * API surface only references @c GArray and @c GByteArray as opaque
+ * pointers, so opaque forward-decls are sufficient — and shadowing real
+ * glib for the libqemu-cxx target only is safe because nothing in qbox
+ * C++ uses real glib internals.
+ */
+#ifndef GLIB_QBOX_SHIM_H
+#define GLIB_QBOX_SHIM_H
+
+typedef struct _GArray GArray;
+typedef struct _GByteArray GByteArray;
+
+#endif


### PR DESCRIPTION
- Add a small glib.h shim under qemu-components/common/include/glib_shim with opaque forward-decls of GArray and GByteArray. libqemu's typedefs.h is wrapped in extern "C" and pulls in qemu-plugin.h, which itself includes <glib.h>.