### PR TITLE
ports/target: guard b_transport against an uninitialized bridge

### DIFF
--- a/qemu-components/common/include/ports/target.h
+++ b/qemu-components/common/include/ports/target.h
@@ -96,6 +96,11 @@ public:
             return;
         }
 
+        if (m_inst == nullptr) {
+            trans.set_response_status(tlm::TLM_OK_RESPONSE);
+            return;
+        }
+
         current_cpu_save = push_current_cpu(trans);
 
         /*


### PR DESCRIPTION
TlmTargetToQemuBridge::b_transport() dereferences m_inst via
m_inst->get().lock_iothread() to take the BQL before dispatching to
QEMU. m_inst is only set by init()/init_with_mr(); a bridge that never
got initialized has m_inst == nullptr.

A gs::loader doing an ELF/bin transport_dbg at end_of_elaboration can
route through the router to such an uninitialized bridge, causing a
NULL dereference and a segfault. Return TLM_OK_RESPONSE as a no-op in
that case instead of crashing.

Signed-off-by: Matheus Tavares Bernardino <matheus.bernardino@oss.qualcomm.com>
