### PR TITLE
ports/target: don't crash on transport to an uninitialized bridge

### DIFF
--- a/qemu-components/common/include/ports/target.h
+++ b/qemu-components/common/include/ports/target.h
@@ -96,6 +96,11 @@ public:
             return;
         }
 
+        if (m_inst == nullptr) {
+            trans.set_response_status(tlm::TLM_OK_RESPONSE);
+            return;
+        }
+
         current_cpu_save = push_current_cpu(trans);
 
         /*


### PR DESCRIPTION
A QemuTargetSocket's bridge is only wired up to its QEMU instance once
init()/init_with_mr() runs. Before that, m_inst is null and the socket
cannot service a transaction.

Nothing stops a transaction from arriving early, though: a gs::loader
loads its image at end_of_elaboration, and that access can be routed by
the router to a bridge that hasn't been initialized yet. b_transport
then dereferences the null m_inst and segfaults.

Bail out early with TLM_OK_RESPONSE when the bridge is uninitialized so
the access is a harmless no-op instead of a crash.

Signed-off-by: Matheus Tavares Bernardino <matheus.bernardino@oss.qualcomm.com>
