### PR TITLE
Remove the link to 'gmock' and 'gtest' from boilerplate.cmake

### DIFF
--- a/cmake/boilerplate.cmake
+++ b/cmake/boilerplate.cmake
@@ -265,7 +265,6 @@ macro(gs_enable_testing)
             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
           )
         endif()
-        target_link_libraries(${PROJECT_NAME} INTERFACE gtest gmock)
       endif()
       enable_testing()
       cmake_host_system_information(RESULT _nproc QUERY NUMBER_OF_LOGICAL_CORES)

--- a/tests/components/memory-blocs/CMakeLists.txt
+++ b/tests/components/memory-blocs/CMakeLists.txt
@@ -1,6 +1,6 @@
 macro(gs_add_test test)
     add_executable(${test} ${test}.cc)
-    target_link_libraries(${test} PRIVATE gs_memory ${TARGET_LIBS})
+    target_link_libraries(${test} PRIVATE gtest gs_memory ${TARGET_LIBS})
     add_test(NAME ${test} COMMAND ${test})
     set_tests_properties(${test} PROPERTIES TIMEOUT 30)
 endmacro()

--- a/tests/utils/cci/CMakeLists.txt
+++ b/tests/utils/cci/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_executable(cci_test cci_test.cc)
-target_link_libraries(cci_test ${TARGET_LIBS})
+target_link_libraries(cci_test gmock gtest ${TARGET_LIBS})
 add_test(NAME cci_test COMMAND cci_test --gs_luafile ${CMAKE_CURRENT_SOURCE_DIR}/../test.lua -p MyTopThree.MyCtrl.log_level=0)
 set_tests_properties(cci_test PROPERTIES TIMEOUT 30)

--- a/tests/utils/cci_alias/CMakeLists.txt
+++ b/tests/utils/cci_alias/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_executable(cci_alias_test cci_alias_test.cc)
-target_link_libraries(cci_alias_test ${TARGET_LIBS})
+target_link_libraries(cci_alias_test gmock gtest ${TARGET_LIBS})
 add_test(NAME cci_alias_test COMMAND cci_alias_test --param MyTopThree.lua_conf=\"${CMAKE_CURRENT_SOURCE_DIR}/../test.lua\")
 set_tests_properties(cci_alias_test PROPERTIES TIMEOUT 30)

--- a/tests/utils/logger/CMakeLists.txt
+++ b/tests/utils/logger/CMakeLists.txt
@@ -1,6 +1,6 @@
 macro(gs_test test)
     add_executable(${test} ${test}.cc)
-    target_link_libraries(${test} ${TARGET_LIBS})
+    target_link_libraries(${test} gmock gtest ${TARGET_LIBS})
     add_test(NAME ${test}_gslog COMMAND ${test})
     set_tests_properties(${test}_gslog PROPERTIES ENVIRONMENT GS_LOG=1)
     set_tests_properties(${test}_gslog PROPERTIES TIMEOUT 30)

--- a/tests/utils/lua/CMakeLists.txt
+++ b/tests/utils/lua/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_executable(lua_test lua_test.cc)
-target_link_libraries(lua_test ${TARGET_LIBS})
+target_link_libraries(lua_test gmock gtest ${TARGET_LIBS})
 add_test(NAME lua_test COMMAND lua_test --gs_luafile ${CMAKE_CURRENT_SOURCE_DIR}/../test.lua --param top.cmdvalue=1010 --p top.allvalue=1050)
 set_tests_properties(lua_test PROPERTIES TIMEOUT 30)

--- a/tests/utils/scp_logging/CMakeLists.txt
+++ b/tests/utils/scp_logging/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_executable(scp_logging_test scp_logging_test.cc)
-target_link_libraries(scp_logging_test ${TARGET_LIBS} scp::tlm_extensions::initiator_id scp::tlm_extensions::path_trace)
+target_link_libraries(scp_logging_test gmock gtest ${TARGET_LIBS} scp::tlm_extensions::initiator_id scp::tlm_extensions::path_trace)
 add_test(NAME scp_logging_test COMMAND scp_logging_test --gs_luafile ${CMAKE_CURRENT_SOURCE_DIR}/../test.lua --param log_level=0)
 set_tests_properties(scp_logging_test PROPERTIES TIMEOUT 30)


### PR DESCRIPTION
Hello,

Currently the link to 'gmock' and 'gtest' is done in boilerplate.cmake (and in several tests cmake files).
I would like to remove this link from boilerplate.cmake as it create unnecessary dependencies for others .so files (for example if you do a `ldd uart-pl011.so` you will see the dependency).

Best Regards,
Benoît