### PR TITLE
cpu_riscv64: add set_resetvec() via runtime resetvec property

### DIFF
--- a/qemu-components/cpu_riscv/cpu_riscv64/include/riscv64.h
+++ b/qemu-components/cpu_riscv/cpu_riscv64/include/riscv64.h
@@ -96,6 +96,9 @@ public:
         qemu::CpuRiscv32 cpu(get_qemu_dev());
         cpu.register_reset();
     }
+
+    // Runtime reset-vector override; the core re-reads it on the next reset.
+    void set_resetvec(uint64_t addr) { get_qemu_dev().set_prop_uint("resetvec", addr); }
 };
 
 class cpu_riscv64 : public QemuCpuRiscv64


### PR DESCRIPTION
Add a runtime reset-vector override that sets the "resetvec" QOM property (runtime-settable in libqemu via realized_set_allowed). The CPU re-reads env.resetvec on the next reset, so pairing this with a reset pulse redirects the core. 