### PR TITLE
monitor: honor the address argument in the /transport_dbg route

### DIFF
--- a/systemc-components/monitor/src/monitor.cc
+++ b/systemc-components/monitor/src/monitor.cc
@@ -368,7 +368,7 @@ void monitor<BUSWIDTH>::init_monitor()
         uint32_t data;
         tlm::tlm_generic_payload txn;
         txn.set_command(tlm::TLM_READ_COMMAND);
-        txn.set_address(0);
+        txn.set_address(addr);
         txn.set_data_ptr(reinterpret_cast<unsigned char*>(&data));
         txn.set_data_length(4);
         txn.set_streaming_width(4);


### PR DESCRIPTION
## Problem

The monitor's `/transport_dbg/<int>/<str>` REST route parses an address from the URL but never uses it. The TLM payload address is hardcoded to `0`, so every debug read returns the word at offset 0 of the target socket, regardless of the requested address:

https://github.com/qualcomm/qbox/blob/c00e7f79d360a3d07a08447dfba56cbbda6582b5/systemc-components/monitor/src/monitor.cc#L358-L371

This contradicts the documented behavior ("Read 4 bytes at address `<decimal_addr>`"):

https://github.com/qualcomm/qbox/blob/c00e7f79d360a3d07a08447dfba56cbbda6582b5/docs/monitor-debugging-guide.md#L78-L90

## Root cause

`txn.set_address(0);` at [monitor.cc#L371](https://github.com/qualcomm/qbox/blob/c00e7f79d360a3d07a08447dfba56cbbda6582b5/systemc-components/monitor/src/monitor.cc#L371) — the `addr` lambda parameter is accepted but unused.

## Fix

One line: use the parsed `addr` as the transaction address.

The two other `set_address(0)` calls in this file (the object-hierarchy JSON preview helpers, [L162](https://github.com/qualcomm/qbox/blob/c00e7f79d360a3d07a08447dfba56cbbda6582b5/systemc-components/monitor/src/monitor.cc#L162) and [L200](https://github.com/qualcomm/qbox/blob/c00e7f79d360a3d07a08447dfba56cbbda6582b5/systemc-components/monitor/src/monitor.cc#L200)) are intentional first-word previews with no address parameter available, and are left untouched.

## How verified

Verified on a v7.3.0-based aarch64 platform by reading device registers at non-zero offsets through the platform router via `/transport_dbg`:

- Before the fix: reads at `+0x004` / `+0x008` / `+0x00C` inside a device's register window all returned the register at offset 0.
- After the fix: each read returns the correct register value at the requested offset.

Note: this likely also explains the "GIC debug transport" limitation recorded in the debugging guide ([docs/monitor-debugging-guide.md#L98-L104](https://github.com/qualcomm/qbox/blob/c00e7f79d360a3d07a08447dfba56cbbda6582b5/docs/monitor-debugging-guide.md#L98-L104) and [#L268-L270](https://github.com/qualcomm/qbox/blob/c00e7f79d360a3d07a08447dfba56cbbda6582b5/docs/monitor-debugging-guide.md#L268-L270)) — the offset was being dropped by the monitor route itself, not by the GIC model. Happy to update those doc paragraphs in this PR or a follow-up, as maintainers prefer.