### PR TITLE
Allow libqemu to be built outside of CPM.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,7 +373,7 @@ if (NOT WITHOUT_QEMU)
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/qemu-components/common/include/glib_shim>
     )
 
-    target_link_libraries(${PROJECT_NAME} PUBLIC libqemu)
+    target_link_libraries(${PROJECT_NAME} PUBLIC libqemu::libqemu)
 
     set(LIBQEMU_CXX_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/qemu-components/common/include/libqemu-cxx)
     install(DIRECTORY ${LIBQEMU_CXX_INCLUDE_DIR} TYPE INCLUDE)


### PR DESCRIPTION
Hello,

I tried to build Qbox by compiling libqemu outside CPM.
To do that I set the following environment variables:
export CPM_USE_LOCAL_PACKAGES=ON
export libqemu_ROOT=<path to my libqemu install>/lib64/cmake/libqemu'

Unfortunately, it currently fails to compile (an include error occurred in this case). To resolve this issue, I updated the Qbox CMakeLists.txt file.

Best Regards,
Benoît