### PR TITLE
Package-lock: update libqemu to libqemu-v11.0-v0.11

### DIFF
--- a/package-lock.cmake
+++ b/package-lock.cmake
@@ -27,7 +27,7 @@ CPMDeclarePackage(SCP
 CPMDeclarePackage(qemu
     NAME libqemu
     GIT_REPOSITORY ${LIBQEMU_GIT}
-    GIT_TAG libqemu-v11.0-v0.10
+    GIT_TAG libqemu-v11.0-v0.11
     GIT_SUBMODULES CMakeLists.txt
     GIT_SHALLOW ON
 )


### PR DESCRIPTION
- hw/timer/qct-qtimer: use 56-bit counter width
- hw/timer/qct-qtimer: accept 64-bit MMIO accesses for hex_timer_ops
- target/riscv: allow setting resetvec after realize
- libqemu: build QEMU in parallel, generator-aware
- ci: fix macOS failures due to untrusted quic homebrew tap