### PR TITLE
docs: document the extern "C" module_register() requirement for dynamically loaded modules

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -141,3 +141,11 @@ completing the bidirectional data path. The same pattern
 applies when using `char_backend_socket` or `char_backend_file`
 -- simply replace the backend instance name and set the
 appropriate CCI parameters.
+
+Note the `dylib_path` parameter on the UART: it makes the
+platform load the `Pl011` model from the `uart-pl011` shared
+library at runtime. A library loaded this way must export an
+`extern "C" void module_register()` hook that registers the
+module type -- see
+[Loading Components from Shared Libraries](configuration.md#loading-components-from-shared-libraries)
+for the details of this contract.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,6 +50,82 @@ platform = {
 }
 ```
 
+## Loading Components from Shared Libraries
+
+A `moduletype` normally refers to a component built into the
+platform binary. When the module factory does not find the type
+among the registered components, it loads it from a shared
+library at elaboration time. The library name is taken from the
+module's `dylib_path` parameter if set, otherwise from its
+`moduletype`, and the platform-specific extension (`.so` on
+Linux, `.dylib` on macOS, `.dll` on Windows) is appended:
+
+```lua
+    uart_0 = {
+        moduletype = "Pl011",
+        dylib_path = "uart-pl011",
+        -- ...
+    },
+```
+
+### The `module_register()` Hook
+
+A component loaded from a shared library must export a
+registration hook with **C linkage**:
+
+```cpp
+extern "C" void module_register();
+```
+
+After loading the library, the module factory looks up the
+symbol `module_register` by its unmangled name and calls it.
+The hook must register the component's constructor with the
+module factory under the same name used as `moduletype`, which
+is done with the `GSC_MODULE_REGISTER_C` macro from
+`module_factory_registery.h`. The macro takes the class name
+followed by the types of the constructor arguments after the
+initial `sc_module_name`:
+
+```cpp
+// mycomp.h
+#include <module_factory_registery.h>
+
+class mycomp : public sc_core::sc_module
+{
+public:
+    mycomp(sc_core::sc_module_name name, sc_core::sc_object* obj);
+    // ...
+};
+
+extern "C" void module_register();
+```
+
+```cpp
+// mycomp.cc
+#include <mycomp.h>
+
+void module_register() { GSC_MODULE_REGISTER_C(mycomp, sc_core::sc_object*); }
+```
+
+The `extern "C"` declaration is essential. Without it, the hook
+is exported under its C++ mangled name (for example
+`_Z15module_registerv`), the factory cannot resolve the
+`module_register` symbol, and registration is skipped with only
+a warning. Elaboration then fails with an error that does not
+point at the real cause:
+
+```
+Error: ModuleFactory: Can't find module type: mycomp
+```
+
+Note that the definition in `mycomp.cc` picks up C linkage from
+the declaration in the included header, so `extern "C"` is only
+needed in one place. All in-tree components follow this pattern
+(see for example
+`systemc-components/keep_alive/include/keep_alive.h`); a
+definition compiled without such a declaration in scope exports
+a mangled symbol and cannot be loaded.
+
 ## YAML Configuration
 
 If you prefer YAML, the `lyaml` library provides a bridge.

--- a/systemc-components/common/include/module_factory_container.h
+++ b/systemc-components/common/include/module_factory_container.h
@@ -95,7 +95,14 @@ public:
                 SC_REPORT_ERROR("ModuleFactory", ("Null module type: " + moduletype).c_str());
             }
         } else {
-            SC_REPORT_ERROR("ModuleFactory", ("Can't find module type: " + moduletype).c_str());
+            SC_REPORT_ERROR("ModuleFactory",
+                            ("Can't find module type: " + moduletype +
+                             ". If this module should be loaded from a shared library, check that the library "
+                             "exports the registration hook as extern \"C\" void module_register() (without "
+                             "extern \"C\" the symbol is mangled and cannot be found), and that the hook "
+                             "registers the type '" +
+                             moduletype + "'")
+                                .c_str());
         }
         __builtin_unreachable();
     }
@@ -952,7 +959,10 @@ public:
             module_register = reinterpret_cast<void (*)()>(libraryHandle->get_symbol("module_register"));
             module_register();
         } else {
-            SCP_WARN(()) << "module_register not found in library " << libname;
+            SCP_WARN(()) << "module_register not found in library " << libname
+                         << ": no module type can be registered from it. Check that the hook is declared with C "
+                            "linkage: extern \"C\" void module_register(); (without extern \"C\" the symbol is "
+                            "mangled and cannot be resolved by name)";
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #90

The module factory loads out-of-tree components by resolving the unmangled symbol `module_register` in the shared library named via `dylib_path`/`moduletype` (`register_module_from_dylib()` in `module_factory_container.h`). The hook must therefore be declared `extern "C"` -- as every in-tree component does -- but this requirement was not documented, and missing it produces a misleading failure: the library loads, registration is skipped with only a warning, and elaboration aborts with `Can't find module type: <X>`, which points at the configuration rather than at C++ name mangling.

## Changes

**Documentation**

- `docs/configuration.md`: new *Loading Components from Shared Libraries* section documenting how the library name is resolved (`dylib_path`, falling back to `moduletype`, plus the platform extension) and the `module_register()` contract: the hook must be exported with C linkage and must register the component under the same name used as `moduletype` (via `GSC_MODULE_REGISTER_C`), with a minimal header/source example mirroring the in-tree pattern (e.g. `keep_alive.h`). It also documents the failure mode when `extern "C"` is missing, and the subtlety that the definition picks up C linkage from the declaration in the included header.
- `docs/backends.md`: the Lua example there was the only place `dylib_path` appeared in the docs -- added a short note next to it cross-referencing the new section.

**Diagnostics** (`module_factory_container.h`)

- The `SCP_WARN` emitted when `module_register` is not found in a successfully loaded library now names the likely cause (missing `extern "C"` linkage, so the exported symbol is mangled).
- The `SC_REPORT_ERROR` in `construct_module()` -- the message users actually see -- now explains, when a library was loaded but the requested type is still unregistered, that the library must export `extern "C" void module_register()` and that the hook must register the exact requested type name.

On the issue's suggestion to escalate the warning to an error: it is kept as a warning deliberately. A library can legitimately register its types from static initializers at load time (e.g. `GSC_MODULE_REGISTER_C` at global scope) without exporting a `module_register` hook, and escalating would break that case. Instead, the fatal-by-default `construct_module` error now carries the full hint at the point where the failure is certain.

## Testing

- The docs changes are markdown only.
- The header change only rewords two diagnostic messages; verified clang-format-clean against the repo's `.clang-format`.
