### PR TITLE
ci: fix ubuntu-builds workflow indentation

### DIFF
--- a/.github/workflows/ubuntu-builds.yml
+++ b/.github/workflows/ubuntu-builds.yml
@@ -37,9 +37,9 @@ jobs:
         if: matrix.os == 'ubuntu-24.04' && matrix.preset == 'gcc'
         run: tar -C build -cf qbox-install.tar install
 
-       - name: Upload qbox install tree
-         if: matrix.os == 'ubuntu-24.04' && matrix.preset == 'gcc'
-         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - name: Upload qbox install tree
+        if: matrix.os == 'ubuntu-24.04' && matrix.preset == 'gcc'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: qbox-install-ubuntu-24.04-gcc
           path: qbox-install.tar
@@ -59,8 +59,8 @@ jobs:
           sudo scripts/install_dependencies.sh
           sudo apt-get install -y gcc-aarch64-linux-gnu
 
-       - name: Download qbox install tree
-         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      - name: Download qbox install tree
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: qbox-install-ubuntu-24.04-gcc
           path: "${{ runner.temp }}/qbox-artifact"


### PR DESCRIPTION
Two steps were indented one space too deep, making the workflow unparseable, so it was silently skipped and never scheduled. Realign them with the surrounding steps.