### PR TITLE
virtio_gpu_gl_pci: gate host-visible/blob behind a param and fix hostmem size

### DIFF
--- a/qemu-components/pci/virtio_gpu.h
+++ b/qemu-components/pci/virtio_gpu.h
@@ -8,6 +8,9 @@
 #ifndef _LIBQBOX_COMPONENTS_VIRTIO_GPU_H
 #define _LIBQBOX_COMPONENTS_VIRTIO_GPU_H
 
+#include <cstdint>
+#include <string>
+
 #include <cci_configuration>
 
 #include <libgssync.h>
@@ -18,6 +21,8 @@ class QemuVirtioGpu : public qemu_gpex::Device
 {
 public:
     cci::cci_param<uint8_t> p_outputs;
+    cci::cci_param<uint64_t> p_hostmem_mb;
+    cci::cci_param<bool> p_enable_host_visible;
 
     void before_end_of_elaboration() override
     {
@@ -37,9 +42,53 @@ protected:
 
     QemuVirtioGpu(const sc_core::sc_module_name& name, QemuInstance& inst, const char* gpu_type, qemu_gpex* gpex,
                   const char* device_id)
-        : qemu_gpex::Device(name, inst, gpu_type, device_id), p_outputs("outputs", 1, "Number of outputs for this gpu")
+        : qemu_gpex::Device(name, inst, gpu_type, device_id)
+        , p_outputs("outputs", 1, "Number of outputs for this gpu")
+        , p_hostmem_mb("hostmem_mb", 2048, "MB to allocate for the host-visible shared-memory region")
+        , p_enable_host_visible("enable_host_visible", false,
+                                "Enable virtio-gpu blob resources and the host-visible shared-memory region "
+                                "(virglrenderer >= 1.0 / QEMU >= 11). Defaults to false to keep the pre-1.0 "
+                                "PCI layout (no SHARED_MEMORY_CFG capability / large BAR), which all guests "
+                                "support. Set true for guests that support and benefit from host-visible blob "
+                                "resources (e.g. modern Linux/Mesa).")
     {
         gpex->add_device(*this);
+    }
+
+    /*
+     * Host-visible / blob-resource setup shared by the 3D GPU variants
+     * (virtio-gpu-gl/cl/qnn). The availability of the blob API is a per-renderer
+     * compile-time decision, so callers must guard these with their own
+     * HAVE_*_RESOURCE_BLOB macro; at runtime the setup is gated by the
+     * enable_host_visible parameter.
+     */
+
+    /* Call from the derived constructor: adds the memfd host-visible backend. */
+    void setup_host_visible_backend()
+    {
+        if (!p_enable_host_visible) {
+            return;
+        }
+        m_inst.add_arg("-object");
+        std::string memory_object = "memory-backend-memfd,id=mem1,size=" + std::to_string(p_hostmem_mb.get_value()) +
+                                    "M";
+        m_inst.add_arg(memory_object.c_str());
+        m_inst.add_arg("-machine");
+        m_inst.add_arg("memory-backend=mem1");
+    }
+
+    /* Call from the derived before_end_of_elaboration(): sets the device props. */
+    void apply_host_visible_props()
+    {
+        if (!p_enable_host_visible) {
+            return;
+        }
+        get_qemu_dev().set_prop_bool("blob", true);
+        /*
+         * QEMU's "hostmem" is a DEFINE_PROP_SIZE property expressed in BYTES, but
+         * p_hostmem_mb is in MB. Convert (64-bit: 2048 * 1MB overflows int).
+         */
+        get_qemu_dev().set_prop_int("hostmem", (int64_t)p_hostmem_mb.get_value() * 1024 * 1024);
     }
 };
 #endif

--- a/qemu-components/pci/virtio_gpu_cl_pci/include/virtio_gpu_cl_pci.h
+++ b/qemu-components/pci/virtio_gpu_cl_pci/include/virtio_gpu_cl_pci.h
@@ -17,8 +17,6 @@ class virtio_gpu_cl_pci : public QemuVirtioGpu
     static constexpr const char* _device_type = "virtio-gpu-cl-pci";
 
 public:
-    cci::cci_param<uint64_t> p_hostmem_mb;
-
     virtio_gpu_cl_pci(const sc_core::sc_module_name& name, sc_core::sc_object* o, sc_core::sc_object* t);
     virtio_gpu_cl_pci(const sc_core::sc_module_name& name, QemuInstance& inst, qemu_gpex* gpex);
 

--- a/qemu-components/pci/virtio_gpu_cl_pci/src/virtio_gpu_cl_pci.cc
+++ b/qemu-components/pci/virtio_gpu_cl_pci/src/virtio_gpu_cl_pci.cc
@@ -17,18 +17,12 @@ virtio_gpu_cl_pci::virtio_gpu_cl_pci(const sc_core::sc_module_name& name, sc_cor
 }
 virtio_gpu_cl_pci::virtio_gpu_cl_pci(const sc_core::sc_module_name& name, QemuInstance& inst, qemu_gpex* gpex)
     : QemuVirtioGpu(name, inst, _device_type, gpex, std::string(name).append(".").append(_device_type).c_str())
-    , p_hostmem_mb("hostmem_mb", 2048, "MB to allocate for host visible shared memory")
 {
 #ifndef __APPLE__
 #ifdef HAVE_VCL_RESOURCE_BLOB
-    // Create memory object for host visible shared memory only if blob
-    // resources are available in virgl otherwise it is not needed.
-    // Also we can NOT enable it on MacOS as it does not have memfd support.
-    m_inst.add_arg("-object");
-    auto memory_object = "memory-backend-memfd,id=mem1,size=" + std::to_string(p_hostmem_mb.get_value()) + "M";
-    m_inst.add_arg(memory_object.c_str());
-    m_inst.add_arg("-machine");
-    m_inst.add_arg("memory-backend=mem1");
+    // Host-visible / blob setup (shared by QemuVirtioGpu, gated by
+    // enable_host_visible). Not available on MacOS (no memfd support).
+    setup_host_visible_backend();
 #endif // HAVE_VCL_RESOURCE_BLOB
 #endif // NOT __APPLE__
 }
@@ -39,11 +33,7 @@ void virtio_gpu_cl_pci::before_end_of_elaboration()
 
 #ifndef __APPLE__
 #ifdef HAVE_VCL_RESOURCE_BLOB
-    // Enable blob resources and host visible shared memory only if
-    // available in virgl and we are NOT on MacOS as it does not have
-    // /dev/udmabuf support.
-    get_qemu_dev().set_prop_bool("blob", true);
-    get_qemu_dev().set_prop_int("hostmem", p_hostmem_mb);
+    apply_host_visible_props();
 #endif // HAVE_VCL_RESOURCE_BLOB
 
     get_qemu_dev().set_prop_bool("context_init", true);

--- a/qemu-components/pci/virtio_gpu_gl_pci/include/virtio_gpu_gl_pci.h
+++ b/qemu-components/pci/virtio_gpu_gl_pci/include/virtio_gpu_gl_pci.h
@@ -19,8 +19,6 @@ private:
     static constexpr const char* _device_type = "virtio-gpu-gl-pci";
 
 public:
-    cci::cci_param<uint64_t> p_hostmem_mb;
-
     virtio_gpu_gl_pci(const sc_core::sc_module_name& name, sc_core::sc_object* o, sc_core::sc_object* t);
     virtio_gpu_gl_pci(const sc_core::sc_module_name& name, QemuInstance& inst, qemu_gpex* gpex);
 

--- a/qemu-components/pci/virtio_gpu_gl_pci/src/virtio_gpu_gl_pci.cc
+++ b/qemu-components/pci/virtio_gpu_gl_pci/src/virtio_gpu_gl_pci.cc
@@ -17,19 +17,12 @@ virtio_gpu_gl_pci::virtio_gpu_gl_pci(const sc_core::sc_module_name& name, sc_cor
 }
 virtio_gpu_gl_pci::virtio_gpu_gl_pci(const sc_core::sc_module_name& name, QemuInstance& inst, qemu_gpex* gpex)
     : QemuVirtioGpu(name, inst, _device_type, gpex, std::string(name).append(".").append(_device_type).c_str())
-    , p_hostmem_mb("hostmem_mb", 2048, "MB to allocate for host visible shared memory")
-
 {
 #ifndef __APPLE__
 #ifdef HAVE_VIRGL_RESOURCE_BLOB
-    // Create memory object for host visible shared memory only if blob
-    // resources are available in virgl otherwise it is not needed.
-    // Also we can NOT enable it on MacOS as it does not have memfd support.
-    m_inst.add_arg("-object");
-    auto memory_object = "memory-backend-memfd,id=mem1,size=" + std::to_string(p_hostmem_mb.get_value()) + "M";
-    m_inst.add_arg(memory_object.c_str());
-    m_inst.add_arg("-machine");
-    m_inst.add_arg("memory-backend=mem1");
+    // Host-visible / blob setup (shared by QemuVirtioGpu, gated by
+    // enable_host_visible). Not available on MacOS (no memfd support).
+    setup_host_visible_backend();
 #endif // HAVE_VIRGL_RESOURCE_BLOB
 #endif // NOT __APPLE__
 }
@@ -40,11 +33,7 @@ void virtio_gpu_gl_pci::before_end_of_elaboration()
 
 #ifndef __APPLE__
 #ifdef HAVE_VIRGL_RESOURCE_BLOB
-    // Enable blob resources and host visible shared memory only if
-    // available in virgl and we are NOT on MacOS as it does not have
-    // /dev/udmabuf support.
-    get_qemu_dev().set_prop_bool("blob", true);
-    get_qemu_dev().set_prop_int("hostmem", p_hostmem_mb);
+    apply_host_visible_props();
 #endif // HAVE_VIRGL_RESOURCE_BLOB
     get_qemu_dev().set_prop_bool("context_init", true);
 #endif // NOT __APPLE__

--- a/qemu-components/pci/virtio_gpu_qnn_pci/include/virtio_gpu_qnn_pci.h
+++ b/qemu-components/pci/virtio_gpu_qnn_pci/include/virtio_gpu_qnn_pci.h
@@ -17,8 +17,6 @@ class virtio_gpu_qnn_pci : public QemuVirtioGpu
     static constexpr const char* _device_type = "virtio-gpu-qnn-pci";
 
 public:
-    cci::cci_param<uint64_t> p_hostmem_mb;
-
     virtio_gpu_qnn_pci(const sc_core::sc_module_name& name, sc_core::sc_object* o, sc_core::sc_object* t);
     virtio_gpu_qnn_pci(const sc_core::sc_module_name& name, QemuInstance& inst, qemu_gpex* gpex);
 

--- a/qemu-components/pci/virtio_gpu_qnn_pci/src/virtio_gpu_qnn_pci.cc
+++ b/qemu-components/pci/virtio_gpu_qnn_pci/src/virtio_gpu_qnn_pci.cc
@@ -16,18 +16,12 @@ virtio_gpu_qnn_pci::virtio_gpu_qnn_pci(const sc_core::sc_module_name& name, sc_c
 }
 virtio_gpu_qnn_pci::virtio_gpu_qnn_pci(const sc_core::sc_module_name& name, QemuInstance& inst, qemu_gpex* gpex)
     : QemuVirtioGpu(name, inst, _device_type, gpex, std::string(name).append(".").append(_device_type).c_str())
-    , p_hostmem_mb("hostmem_mb", 2048, "MB to allocate for host visible shared memory")
 {
 #ifndef __APPLE__
 #ifdef HAVE_VQNN_RESOURCE_BLOB
-    // Create memory object for host visible shared memory only if blob
-    // resources are available in virgl otherwise it is not needed.
-    // Also we can NOT enable it on MacOS as it does not have memfd support.
-    m_inst.add_arg("-object");
-    auto memory_object = "memory-backend-memfd,id=mem1,size=" + std::to_string(p_hostmem_mb.get_value()) + "M";
-    m_inst.add_arg(memory_object.c_str());
-    m_inst.add_arg("-machine");
-    m_inst.add_arg("memory-backend=mem1");
+    // Host-visible / blob setup (shared by QemuVirtioGpu, gated by
+    // enable_host_visible). Not available on MacOS (no memfd support).
+    setup_host_visible_backend();
 #endif // HAVE_VQNN_RESOURCE_BLOB
 #endif // NOT __APPLE__
 }
@@ -38,11 +32,7 @@ void virtio_gpu_qnn_pci::before_end_of_elaboration()
 
 #ifndef __APPLE__
 #ifdef HAVE_VQNN_RESOURCE_BLOB
-    // Enable blob resources and host visible shared memory only if
-    // available in virgl and we are NOT on MacOS as it does not have
-    // /dev/udmabuf support.
-    get_qemu_dev().set_prop_bool("blob", true);
-    get_qemu_dev().set_prop_int("hostmem", p_hostmem_mb);
+    apply_host_visible_props();
 #endif // HAVE_VQNN_RESOURCE_BLOB
 
     get_qemu_dev().set_prop_bool("context_init", true);


### PR DESCRIPTION
Change:
Move the virtio-gpu host-visible / blob-resource setup into the shared
QemuVirtioGpu base class and add an "enable_host_visible" cci parameter
(default: false) that gates it. The base now owns the hostmem_mb and
enable_host_visible params plus two helpers - setup_host_visible_backend()
(adds the "-object memory-backend-memfd" machine backend) and
apply_host_visible_props() (sets the device "blob" and "hostmem" props) -
used by all three 3D variants: virtio_gpu_gl_pci, virtio_gpu_cl_pci and
virtio_gpu_qnn_pci. Also fix the wrong memory size: QEMU's "hostmem" is a
DEFINE_PROP_SIZE property expressed in BYTES, but it was set to hostmem_mb
directly (e.g. 2048), i.e. 2048 *bytes* instead of 2048 MB.

Reason:
virglrenderer 1.0 / QEMU 11 (and the vircl / virqnn equivalents) enable the
blob + host-visible shared-memory path by default via the compile-time
HAVE_*_RESOURCE_BLOB checks. On the previous renderers this path was compiled
out, so the device presented the simpler pre-1.0 PCI layout that every guest
supported. Turning it on surfaced two problems, previously duplicated verbatim
across the three near-identical GPU components:
  - Wrong memory size: hostmem was set to 2048 bytes (0x800) instead of 2 GB,
    so the guest host-visible window was only 2 KB. Any real blob-backed buffer
    allocation then failed (e.g. glamor GL_OUT_OF_MEMORY / buffer_size 0),
    giving a black screen / crash-looping greeter on Linux guests.
  - Unusable layout for some guests: the host-visible region adds an extra
    VIRTIO_PCI_CAP_SHARED_MEMORY_CFG capability and a large prefetchable BAR
    that guests such as QNX cannot enumerate, breaking PCI bring-up.
Centralizing the logic keeps the fix and the toggle in one place so it cannot
drift back across the gl / cl / qnn copies.

Behaviour:
  - Default (enable_host_visible=false): the device presents the pre-1.0 PCI
    layout - no SHARED_MEMORY_CFG capability, no large host-visible BAR, no
    memfd backend. Matches the previously working (virglrenderer 0.x / Ubuntu
    22.04 host) behaviour and works for all guests, including QNX.
  - enable_host_visible=true: opt into host-visible blob resources for guests
    that support and benefit from them (e.g. modern Linux/Mesa); the window is
    now sized correctly in bytes (hostmem_mb * 1024 * 1024).
  - Applies uniformly to gl / cl / qnn. Set per instance, e.g.
    platform.gpu_0.enable_host_visible=true.