### PR TITLE
systemc-components/multiinitiator-signal-socket: clear pending values…

### DIFF
--- a/systemc-components/common/include/ports/multiinitiator-signal-socket.h
+++ b/systemc-components/common/include/ports/multiinitiator-signal-socket.h
@@ -37,7 +37,8 @@ public:
             while (vals_valid == false) {
                 wait(ev);
             }
-            std::vector<T> vs = vals; // No race conditions, we are single threaded. COPY the vector
+            std::vector<T> vs;
+            vs.swap(vals);
             vals_valid = false;
             for (auto v : vs) {
                 for (int i = 0; i < this->size(); i++) {


### PR DESCRIPTION
… after dispatch

- The writer thread copied `vals` into a local snapshot but never emptied the source vector, while async_write_vector() appends to that same vector. Swap the pending queue into the local snapshot so it is drained atomically before dispatch.